### PR TITLE
Correct indexing + identifiable random effects

### DIFF
--- a/scripts/sam_models/mod2/01-run-model.R
+++ b/scripts/sam_models/mod2/01-run-model.R
@@ -43,7 +43,11 @@ all <- total %>%
 
 # past_topped is an index of the number of days in the past 30 that were inundated
 
+# check histogram of logged chlorophyll
 hist(log(all$chl))
+
+# check sd among site mean chlorophyll, set as parameter for folded-t prior
+sd(tapply(all$chl, all$station_id, mean))
 
 datlist <- list(chl = log(all$chl),
                 past_topped = all$past_topped,
@@ -72,9 +76,9 @@ jm <- jags.model("scripts/sam_models/mod2/sam_model.JAGS",
 update(jm, n.iter = 1000)
 
 jm_coda <- coda.samples(jm,
-                        variable.names = c("B", "wA", "wB", "wC",
+                        variable.names = c("Bstar", "wA", "wB", "wC",
                                            "deltaA", "deltaB", "deltaC",
-                                           "sig", "tau", "sig.eps", "tau.eps"),
+                                           "sig", "tau", "sig.eps", "Estar"),
                         n.iter = 1000*15,
                         thin = 15)
 
@@ -114,6 +118,10 @@ caterplot(jm_coda,
 
 caterplot(jm_coda,
           parms = "wC",
+          reorder = FALSE)
+
+caterplot(jm_coda,
+          parms = "Estar",
           reorder = FALSE)
 
 # summarize and plot

--- a/scripts/sam_models/mod2/sam_model.JAGS
+++ b/scripts/sam_models/mod2/sam_model.JAGS
@@ -10,7 +10,7 @@ model{
              B[4] * Qant[i] +
              B[5] * Rant[i] +
              B[6] * Tant[i] +
-             Eps[station_id[i]]
+             eps[station_id[i]]
 
   # Sum antecedent components across all timesteps
     Qant[i] <- sum(qTemp[i,])
@@ -21,17 +21,17 @@ model{
     # use lag of
     for(k in 1:nlagA){
       qTemp[i,k] <-
-        mean(Q[(doy1998[i]-k*pA[k]):(doy1998[i]-k*pA[k]+pA[k] - 1)])*wA[k]
+        mean(Q[(doy1998[i]-sum(pA[1:k])):(doy1998[i]-sum(pA[1:k])+pA[k] - 1)])*wA[k]
     }
 
     for(k in 1:nlagB){
       rTemp[i,k] <-
-        mean(Rad[(doy1998[i]-k*pB[k]):(doy1998[i]-k*pB[k]+pB[k] - 1)])*wB[k]
+        mean(Rad[(doy1998[i]-sum(pB[1:k])):(doy1998[i]-sum(pB[1:k])+pB[k] - 1)])*wB[k]
     }
 
     for(k in 1:nlagC){
       tTemp[i,k] <-
-        mean(Temp[(doy1998[i]-k*pC[k]):(doy1998[i]-k*pC[k]+pC[k] - 1)])*wC[k]
+        mean(Temp[(doy1998[i]-sum(pC[1:k])):(doy1998[i]-sum(pC[1:k])+pC[k] - 1)])*wC[k]
     }
   }
 
@@ -59,19 +59,25 @@ model{
 
   # Priors for random effects
   for(r in 1:Nstation){
-    Eps[r] ~ dnorm(0, tau.eps)
+  # non-identifiable random effects
+    eps[r] ~ dnorm(0, tau.eps)
+  # identifable random effects
+    Estar[r] <- eps[r] - mean(eps[])
   }
 
   # Diffuse normal priors for regression coefficients
-  for(i in 1:6){
-    B[i] ~ dnorm(0, 0.001)
+  for(k in 1:6){
+    B[k] ~ dnorm(0, 0.001)
+    # Identifiable parameter vector
+    Bstar[k] <- B[k] + equals(k, 1)*mean(eps[])
   }
 
 
-  # Diffuse gamma priors for observation-level and random effect precisions
+  # Diffuse gamma prior for observation-level precisions
   tau ~ dgamma(0.01, 0.01)
   sig <- 1/sqrt(tau)
 
-  tau.eps ~ dgamma(0.01, 0.01)
-  sig.eps <- 1/sqrt(tau.eps)
+  # Diffuse folded-t prior for random-effect standard deviation
+  sig.eps ~ dt(0, 10, 2)
+  tau.eps <- pow(abs(sig.eps), -2)
 }

--- a/scripts/sam_models/mod2/sam_model.JAGS
+++ b/scripts/sam_models/mod2/sam_model.JAGS
@@ -78,6 +78,7 @@ model{
   sig <- 1/sqrt(tau)
 
   # Diffuse folded-t prior for random-effect standard deviation
+  # Most effective for smaller number of groups
   sig.eps ~ dt(0, 10, 2)
   tau.eps <- pow(abs(sig.eps), -2)
 }


### PR DESCRIPTION
 - indexing should now be correct. Intermediate dummy variables are not allowed by JAGS apparently, so the code is still difficult to read, but should work. 
 - I added the identifiable RE and intercept terms, now `Estar` and `Bstar` in the model. The mean of the REs is subtracted from each RE and added to the intercept. 
 - Due to small group size (10 stations), I changed the prior from a tau.eps ~ dgamma(0.01, 0.01) to a sig.eps ~ dt(0, 10, 2). The folded t is recommended by Gelman (2006) as weakly informative and appropriate for hierarchical model variance terms. 