### PR TITLE
further review of missing chl-a data (n=14)

### DIFF
--- a/data_publication/R/compare_chla.R
+++ b/data_publication/R/compare_chla.R
@@ -5,14 +5,12 @@ library(stringr)
 library(flextable)
 library(lubridate)
 
-setwd("C:/Users/estumpne/Documents/R/swg-21-connectivity/data_publication")
-
 #new model data
-new <- read_csv("C:/Users/estumpne/Documents/R/swg-21-connectivity/data_publication/data_clean/model_chla_covars.csv")
+
 new <- read_csv("data_publication/data_clean/model_chla_covars.csv")
 
 #old model data
-old <- read_csv("C:/Users/estumpne/Documents/R/swg-21-connectivity/data_model/model_chla_covars_gam.csv")
+
 old <- read_csv("data_model/model_chla_covars_gam.csv")
 
 #filter old model data to inundation period
@@ -72,10 +70,33 @@ missing <- distinct(all) #produced 22, which is different from compare table (I 
 missing <- all %>%
   distinct(.keep_all = TRUE)
 
+#test direct WQP retrieval - "missing" samples are in WQP-----------------
 
+#library(dataRetrieval)
 
+#siteNumbers<-c('USGS-11455139',
+               #'USGS-11455478')
 
+#parameterCd <- "70953"
 
+#cawsc <- readWQPqw(siteNumbers, parameterCd)
 
+#remove unneeded columns
 
+#cawsc_sub <- subset(cawsc, select = c('MonitoringLocationIdentifier', 'ActivityStartDateTime', 'ResultMeasureValue'))
+
+#review discretewq package----------------------------
+#bring in discretewq > data > USGS_CAWSC.rda to environ - "missing" samples are in discretewq
+
+#filt_discretewq <- USGS_CAWSC %>%
+  #subset(Station %in% c('USGS-11455139', 'USGS-11455478')) %>%
+  #filter(!is.na(Chlorophyll)) %>%
+  #select(2,5,8)
+
+#reveiw results of NCEAS f_clean_discretewq - "missing" samples are missing---------------
+
+#NCEAS_clean_discretewq<- read_csv("data_publication/data_clean/clean_discretewq.csv")
+
+#NCEAS_clean <- NCEAS_clean_discretewq %>%
+  #subset(station %in% c('USGS-11455139', 'USGS-11455478'))
 

--- a/data_publication/R/f_clean_discretewq.R
+++ b/data_publication/R/f_clean_discretewq.R
@@ -22,7 +22,7 @@ f_clean_discretewq <- function(){
     lat_mean <- mean(wq_raw$Latitude)
     long_mean <- mean(wq_raw$Longitude)
 
-  # save raw file
+  # filter and clean
     wq_raw <- source_url  %>%
     read_csv(show_col_types = FALSE) %>%
     filter(!is.na(Chlorophyll)) %>% ##remove observations without Chla data


### PR DESCRIPTION
@ryanpeek Hoping you can take a look at the data_publication/compare_chla.R script. There are 14 missing samples from 2 USGS stations in the new model dataset when compared against the old model dataset. Data are in the discretewq package that is the source of the f_clean_discretewq.R script. I'm unsure how they're getting dropped.